### PR TITLE
Allowing streaming of COBS indexes

### DIFF
--- a/cobs/file/classic_index_header.cpp
+++ b/cobs/file/classic_index_header.cpp
@@ -36,17 +36,20 @@ void ClassicIndexHeader::serialize(std::ostream& os) const {
 }
 
 void ClassicIndexHeader::deserialize(std::istream& is) {
-    deserialize_magic_begin(is, magic_word, version);
+    std::streamsize nb_of_bytes_read = 0;
+    nb_of_bytes_read += deserialize_magic_begin(is, magic_word, version);
 
     uint32_t file_names_size;
-    stream_get(is, term_size_, canonicalize_,
+    nb_of_bytes_read += stream_get(is, term_size_, canonicalize_,
                file_names_size, signature_size_, num_hashes_);
     file_names_.resize(file_names_size);
     for (auto& file_name : file_names_) {
         std::getline(is, file_name);
+        nb_of_bytes_read += file_name.size() + 1;
     }
 
-    deserialize_magic_end(is, magic_word);
+    nb_of_bytes_read += deserialize_magic_end(is, magic_word);
+    header_size_ = nb_of_bytes_read;
 }
 
 void ClassicIndexHeader::write_file(std::ostream& os,

--- a/cobs/file/classic_index_header.hpp
+++ b/cobs/file/classic_index_header.hpp
@@ -26,6 +26,8 @@ public:
     uint64_t num_hashes_;
     //! list of document file names
     std::vector<std::string> file_names_;
+    //! header size in bytes
+    std::streamsize header_size_;
 
 public:
     static const std::string magic_word;

--- a/cobs/file/header.hpp
+++ b/cobs/file/header.hpp
@@ -20,12 +20,13 @@
 namespace cobs {
 
 static inline
-void check_magic_word(std::istream& is, const std::string& magic_word) {
+std::streamsize check_magic_word(std::istream& is, const std::string& magic_word) {
     std::vector<char> mw_v(magic_word.size(), ' ');
     is.read(mw_v.data(), magic_word.size());
     std::string mw(mw_v.data(), mw_v.size());
     assert_throw<FileIOException>(mw == magic_word, "invalid file type");
     assert_throw<FileIOException>(is.good(), "input filestream broken");
+    return is.gcount();
 }
 
 static inline
@@ -43,19 +44,21 @@ void serialize_magic_end(
 }
 
 static inline
-void deserialize_magic_begin(
+std::streamsize deserialize_magic_begin(
     std::istream& is, const std::string& magic_word, const uint32_t& version) {
-    check_magic_word(is, "COBS:");
-    check_magic_word(is, magic_word);
+    std::streamsize nb_of_bytes_read = 0;
+    nb_of_bytes_read += check_magic_word(is, "COBS:");
+    nb_of_bytes_read += check_magic_word(is, magic_word);
     uint32_t v;
-    stream_get(is, v);
+    nb_of_bytes_read += stream_get(is, v);
     assert_throw<FileIOException>(v == version, "invalid file version");
+    return nb_of_bytes_read;
 }
 
 static inline
-void deserialize_magic_end(
+std::streamsize deserialize_magic_end(
     std::istream& is, const std::string& magic_word) {
-    check_magic_word(is, magic_word);
+    return check_magic_word(is, magic_word);
 }
 
 } // namespace cobs

--- a/cobs/query/classic_index/mmap_search_file.cpp
+++ b/cobs/query/classic_index/mmap_search_file.cpp
@@ -20,6 +20,12 @@ ClassicIndexMMapSearchFile::ClassicIndexMMapSearchFile(const fs::path& path)
     data_ = handle_.data + stream_pos_.curr_pos;
 }
 
+ClassicIndexMMapSearchFile::ClassicIndexMMapSearchFile(std::ifstream &ifs, int64_t index_file_size)
+    : ClassicIndexSearchFile(ifs, index_file_size) {
+    handle_ = initialize_stream(ifs, stream_pos_.size());
+    data_ = handle_.data;
+}
+
 ClassicIndexMMapSearchFile::~ClassicIndexMMapSearchFile() {
     destroy_mmap(handle_);
 }

--- a/cobs/query/classic_index/mmap_search_file.hpp
+++ b/cobs/query/classic_index/mmap_search_file.hpp
@@ -25,6 +25,7 @@ protected:
 
 public:
     explicit ClassicIndexMMapSearchFile(const fs::path& path);
+    explicit ClassicIndexMMapSearchFile(std::ifstream &ifs, int64_t index_file_size);
     ~ClassicIndexMMapSearchFile();
 };
 

--- a/cobs/query/classic_index/search_file.cpp
+++ b/cobs/query/classic_index/search_file.cpp
@@ -18,6 +18,12 @@ ClassicIndexSearchFile::ClassicIndexSearchFile(const fs::path& path) {
     stream_pos_ = get_stream_pos(ifs);
 }
 
+ClassicIndexSearchFile::ClassicIndexSearchFile(std::ifstream &ifs, int64_t index_file_size) {
+    header_ = deserialize_header<ClassicIndexHeader>(ifs);
+    stream_pos_ = StreamPos { (uint64_t) header_.header_size_, (uint64_t) index_file_size};
+}
+
+
 uint64_t ClassicIndexSearchFile::counts_size() const {
     return 8 * header_.row_size();
 }

--- a/cobs/query/classic_index/search_file.hpp
+++ b/cobs/query/classic_index/search_file.hpp
@@ -18,6 +18,7 @@ class ClassicIndexSearchFile : public IndexSearchFile
 {
 protected:
     explicit ClassicIndexSearchFile(const fs::path& path);
+    explicit ClassicIndexSearchFile(std::ifstream &ifs, int64_t index_file_size);
 
     uint32_t term_size() const final { return header_.term_size_; }
     uint8_t canonicalize() const final { return header_.canonicalize_; }

--- a/cobs/query/search.hpp
+++ b/cobs/query/search.hpp
@@ -78,6 +78,21 @@ static inline std::vector<std::shared_ptr<cobs::IndexSearchFile> > get_cobs_inde
   return indices;
 }
 
+static inline std::vector<std::shared_ptr<cobs::IndexSearchFile> > get_cobs_indexes_given_streams (
+    const std::vector<std::ifstream*> &streams, const std::vector<int64_t> &index_sizes) {
+
+    std::vector<std::shared_ptr<cobs::IndexSearchFile> > indices;
+    for (size_t i=0; i<streams.size(); i++)
+    {
+        std::ifstream *stream = streams[i];
+        int64_t index_file_size = index_sizes[i];
+        indices.push_back(
+          std::make_shared<cobs::ClassicIndexMMapSearchFile>(*stream, index_file_size));
+    }
+
+    return indices;
+}
+
 static inline void process_query(
   cobs::Search &s, double threshold, unsigned num_results,
   const std::string &query_line, const std::string &query_file,

--- a/cobs/util/file.hpp
+++ b/cobs/util/file.hpp
@@ -16,6 +16,7 @@
 #include <cobs/util/fs.hpp>
 
 #include <tlx/die.hpp>
+#include <tlx/logger.hpp>
 
 namespace cobs {
 
@@ -38,6 +39,14 @@ Header deserialize_header(std::ifstream& ifs, const fs::path& p) {
     ifs.exceptions(std::ios::eofbit | std::ios::failbit | std::ios::badbit);
     ifs.open(p.string(), std::ios::in | std::ios::binary);
     die_unless(ifs.good());
+    Header h;
+    h.deserialize(ifs);
+    return h;
+}
+
+template <class Header>
+Header deserialize_header(std::ifstream& ifs) {
+    LOG1 << "Deserializing header from stream";
     Header h;
     h.deserialize(ifs);
     return h;

--- a/cobs/util/query.hpp
+++ b/cobs/util/query.hpp
@@ -30,6 +30,7 @@ struct MMapHandle {
 };
 
 MMapHandle initialize_mmap(const fs::path& path);
+MMapHandle initialize_stream(std::ifstream& is, int64_t index_file_size);
 void destroy_mmap(MMapHandle& handle);
 
 //! Canonicalize a k-mer. Given an input k-mer of length size, checks if should

--- a/cobs/util/serialization.hpp
+++ b/cobs/util/serialization.hpp
@@ -85,20 +85,21 @@ void stream_put(std::ostream& os, const T& t, const Args& ... args) {
 
 //! read a POD from an istream
 template <typename T>
-void stream_get_pod(std::istream& is, T& t) {
+std::streamsize stream_get_pod(std::istream& is, T& t) {
     static_assert(std::is_pod<T>::value, "T must be POD");
     is.read(reinterpret_cast<char*>(&t), sizeof(T));
+    return is.gcount();
 }
 
 //! read a list of PODs from an istream
 static inline
-void stream_get(std::istream& /* is */) { }
+std::streamsize stream_get(std::istream& /* is */) { return 0; }
 
 //! read a list of PODs from an istream
 template <typename T, typename... Args>
-void stream_get(std::istream& is, T& t, Args& ... args) {
-    stream_get_pod(is, t);
-    stream_get(is, args...);
+std::streamsize stream_get(std::istream& is, T& t, Args& ... args) {
+    std::streamsize nb_of_bytes_from_pod = stream_get_pod(is, t);
+    return nb_of_bytes_from_pod + stream_get(is, args...);
 }
 
 } // namespace cobs


### PR DESCRIPTION
Now we can stream COBS indexes into `cobs` (e.g. `cobs ... -i <(xz --decompress --stdout --no-sparse --ignore-check  index.xz)`). To do so, however, we need to know beforehand the index size, which can be passed now with the new option `--index-sizes`. A better implementation would be to store the index size in the header so it can be read even when streaming, but this is for a future PR